### PR TITLE
Show final tic tac toe move and winning line

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,15 +56,20 @@ impl Board {
         }
     }
 
-    pub fn check_winner(&self) -> Option<Cell> {
+    pub fn winning_line(&self) -> Option<[usize; 3]> {
         for &[a, b, c] in WIN_CONDITIONS.iter() {
-            if self.cells[a] != Cell::Empty &&
-               self.cells[a] == self.cells[b] &&
-               self.cells[b] == self.cells[c] {
-                return Some(self.cells[a]);
+            if self.cells[a] != Cell::Empty
+                && self.cells[a] == self.cells[b]
+                && self.cells[b] == self.cells[c]
+            {
+                return Some([a, b, c]);
             }
         }
         None
+    }
+
+    pub fn check_winner(&self) -> Option<Cell> {
+        self.winning_line().map(|line| self.cells[line[0]])
     }
 
     pub fn is_full(&self) -> bool {
@@ -260,5 +265,17 @@ mod tests {
             Cell::O, Cell::X, Cell::X,
         ];
         assert_eq!(board.check_winner(), None);
+    }
+
+    #[test]
+    fn test_winning_line() {
+        let mut board = Board::new();
+        board.cells[0] = Cell::O;
+        board.cells[4] = Cell::O;
+        board.cells[8] = Cell::O;
+        assert_eq!(board.winning_line(), Some([0, 4, 8]));
+
+        board.cells[8] = Cell::X;
+        assert_eq!(board.winning_line(), None);
     }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -59,4 +59,10 @@ impl WasmBoard {
                 Cell::Empty => 0u8,
             })
     }
+
+    pub fn winning_line(&self) -> Option<Box<[u32]>> {
+        self.board
+            .winning_line()
+            .map(|line| line.iter().map(|&i| i as u32).collect::<Vec<u32>>().into_boxed_slice())
+    }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -9,6 +9,8 @@
 </head>
 <body>
     <canvas id="boardCanvas" width="300" height="300"></canvas>
+    <div id="status" style="margin-top:10px;font-weight:bold;"></div>
+    <button id="restartButton" style="display:none;margin-top:5px;">Restart</button>
     <script type="module" src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `Board::winning_line` for the winning combination
- export `winning_line` via the Wasm API
- highlight the winning line in the WebGL frontend
- keep the final board visible until the next click
- add unit test for `winning_line`
- display result text and a restart button instead of alerts

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_686260903e34832a809e01f952d8b755